### PR TITLE
* igdiscover/init.py: Allow species specific options in config

### DIFF
--- a/igdiscover/config.py
+++ b/igdiscover/config.py
@@ -124,10 +124,10 @@ class Config:
 			return Config(file=f)
 
 	@staticmethod
-	def update_option(config_path, options_dict={}):
+	def update_option(config_path, options):
 		with open(config_path) as f:
 			config = ruamel.yaml.load(f, ruamel.yaml.RoundTripLoader)
-			for k, v in options_dict:
+			for k, v in options:
 				v = ruamel.yaml.safe_load(v)
 				item = config
 				# allow nested keys
@@ -159,6 +159,7 @@ def add_arguments(parser):
 		help='Set KEY to VALUE. Use KEY.SUBKEY[.SUBSUBKEY...] for nested keys.')
 	arg('--file', default=Config.DEFAULT_PATH,
 		help='Configuration file to modify. Default: igdiscover.yaml in current directory.')
+
 
 def main(args):
 	if args.set:

--- a/igdiscover/init.py
+++ b/igdiscover/init.py
@@ -29,6 +29,8 @@ do_not_show_cpustats = 1
 def add_arguments(parser):
 	parser.add_argument('--database', '--db', metavar='PATH', default=None,
 		help='Directory with V.fasta, D.fasta and J.fasta files. If not given, a dialog is shown.')
+	parser.add_argument('--species', '--sp', metavar='SPECIES', default='any',
+		help='Initialize default yaml file with species specific settings. Can be set to "any" or "human".')
 	group = parser.add_mutually_exclusive_group()
 	group.add_argument('--single-reads', default=None, metavar='READS',
 		help='File with single-end reads (.fasta.gz or .fastq.gz)')
@@ -317,10 +319,15 @@ def main(args):
 			sys.exit(1)
 		create_symlink(reads1, args.directory, target)
 
-	# Write the configuration file
 	configuration = pkg_resources.resource_string('igdiscover', Config.DEFAULT_PATH).decode()
-	with open(os.path.join(args.directory, Config.DEFAULT_PATH), 'w') as f:
+	# Write the configuration file
+	local_config_path = os.path.join(args.directory, Config.DEFAULT_PATH)
+	with open(local_config_path, 'w') as f:
 		f.write(configuration)
+
+	# Update defaults that are human specific
+	if args.species.lower() == 'human':
+		Config.update_option(local_config_path, [('preprocessing_filter.v_coverage', '97')])
 
 	# Create database files
 	database_dir = os.path.join(args.directory, 'database')

--- a/igdiscover/init.py
+++ b/igdiscover/init.py
@@ -27,10 +27,10 @@ do_not_show_cpustats = 1
 
 
 def add_arguments(parser):
-	parser.add_argument('--database', '--db', metavar='PATH', default=None,
+	parser.add_argument('--database',  metavar='PATH', default=None,
 		help='Directory with V.fasta, D.fasta and J.fasta files. If not given, a dialog is shown.')
-	parser.add_argument('--species', '--sp', metavar='SPECIES', default='any',
-		help='Initialize default yaml file with species specific settings. Can be set to "any" or "human".')
+	parser.add_argument('--species', '--sp', metavar='SPECIES', default='any', choices=('any', 'human'),
+		help='Use configuration settings specific to %(choices)s. Default: %(default)s.')
 	group = parser.add_mutually_exclusive_group()
 	group.add_argument('--single-reads', default=None, metavar='READS',
 		help='File with single-end reads (.fasta.gz or .fastq.gz)')


### PR DESCRIPTION
- This is the first step towards species specific default yaml config.
- Default is 'any' species with a possibility of initializing with 'human'. 
- Current code for updating yaml file is wrapped into function, to update default yaml config depending on whether species specific initialization is called.

This way we can keep maintaining single default yaml file and have species specific defaults.