### PR TITLE
Remove vsearch from dependencies

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,109 +1,116 @@
 # abstract dependencies:
-# python=3.6 sqt seaborn snakemake cutadapt muscle pear flash igblast vsearch ruamel.yaml nomkl
+# python=3.6 seaborn sqt snakemake-minimal cutadapt muscle pear flash igblast=1.7 ruamel.yaml nomkl
 channels:
   - bioconda
   - conda-forge
   - defaults
 dependencies:
   - bcftools=1.9=h4da6232_0
-  - cutadapt=1.17=py36_0
+  - cutadapt=1.18=py36_0
   - flash=1.2.11=ha92aebf_2
-  - htslib=1.7=0
+  - htslib=1.9=hc238db4_4
   - igblast=1.7.0=pl5.22.0_0
   - libdeflate=1.0=h470a237_0
   - muscle=3.8.1551=h2d50403_3
   - pear=0.9.6=he4cf2ce_4
-  - pysam=0.14.1=py36hae42fb6_1
-  - samtools=1.7=1
-  - snakemake-minimal=5.2.2=py36_1
+  - pysam=0.15.1=py36h0380709_0
+  - samtools=1.9=h8ee4bcc_1
+  - snakemake-minimal=5.3.0=py_2
   - sqt=0.8.0=py36h470a237_2
-  - vsearch=2.8.1=h96824bc_0
-  - xopen=0.3.2=py_1
+  - xopen=0.3.5=py_0
   - appdirs=1.4.3=py_1
-  - asn1crypto=0.24.0=py36_2
+  - asn1crypto=0.24.0=py36_1003
+  - attrs=18.2.0=py_0
+  - blas=1.1=openblas
+  - bz2file=0.98=py_0
   - bzip2=1.0.6=h470a237_2
-  - ca-certificates=2018.8.13=ha4d7672_0
-  - certifi=2018.8.13=py36_0
+  - ca-certificates=2018.10.15=ha4d7672_0
+  - certifi=2018.10.15=py36_1000
   - cffi=1.11.5=py36h5e8e0c9_1
-  - chardet=3.0.4=py36_3
+  - chardet=3.0.4=py36_1003
   - configargparse=0.13.0=py_1
   - cryptography=2.3.1=py36hdffb7b8_0
-  - cryptography-vectors=2.3.1=py36_0
-  - curl=7.61.0=h93b3f91_1
+  - cryptography-vectors=2.3.1=py36_1000
+  - curl=7.62.0=h74213dd_0
   - cycler=0.10.0=py_1
   - dbus=1.13.0=h3a4f0e9_0
-  - docutils=0.14=py36_0
-  - expat=2.2.5=hfc679d8_1
-  - fontconfig=2.13.0=h65d0f4c_5
-  - freetype=2.9.1=h6debe1e_1
-  - gettext=0.19.8.1=0
-  - glib=2.55.0=h464dc38_2
+  - docutils=0.14=py36_1001
+  - expat=2.2.5=hfc679d8_2
+  - fontconfig=2.13.1=h65d0f4c_0
+  - freetype=2.9.1=h6debe1e_4
+  - gettext=0.19.8.1=h5e8e0c9_1
+  - gitdb2=2.0.5=py_0
+  - gitpython=2.1.11=py_0
+  - glib=2.56.2=h464dc38_1
   - gst-plugins-base=1.12.5=hde13a9d_0
-  - gstreamer=1.12.5=h61a6719_0
+  - gstreamer=1.12.5=h5856ed1_0
   - icu=58.2=hfc679d8_0
-  - idna=2.7=py36_2
-  - jpeg=9c=h470a237_0
-  - jsonschema=2.6.0=py36_1
+  - idna=2.7=py36_1002
+  - jpeg=9c=h470a237_1
+  - jsonschema=3.0.0a3=py36_1000
   - kiwisolver=1.0.1=py36h2d50403_2
-  - krb5=1.14.6=0
-  - libffi=3.2.1=hfc679d8_4
+  - krb5=1.16.2=hbb41f41_0
+  - libcurl=7.62.0=hbdb9355_0
+  - libedit=3.1.20170329=haf1bffa_1
+  - libffi=3.2.1=hfc679d8_5
   - libgcc=7.2.0=h69d50b8_2
-  - libgcc-ng=7.2.0=hdf63c60_3
-  - libgfortran-ng=7.2.0=hdf63c60_3
-  - libiconv=1.15=h470a237_2
-  - libpng=1.6.35=ha92aebf_0
-  - libssh2=1.8.0=h5b517e9_2
+  - libgfortran=3.0.0=1
+  - libiconv=1.15=h470a237_3
+  - libpng=1.6.35=ha92aebf_2
+  - libssh2=1.8.0=h5b517e9_3
   - libstdcxx-ng=7.2.0=hdf63c60_3
-  - libuuid=2.32.1=h470a237_0
+  - libuuid=2.32.1=h470a237_2
   - libxcb=1.13=h470a237_2
-  - libxml2=2.9.8=h422b904_3
-  - matplotlib=2.2.3=py36h8e2386c_0
+  - libxml2=2.9.8=h422b904_5
+  - matplotlib=3.0.2=py36h8a2030e_1
+  - matplotlib-base=3.0.2=py36h20b835b_1
   - ncurses=6.1=hfc679d8_1
-  - openssl=1.0.2o=h470a237_1
+  - numpy=1.15.4=py36_blas_openblashb06ca3d_0
+  - openblas=0.3.3=ha44fe06_1
+  - openssl=1.0.2p=h470a237_1
   - pandas=0.23.4=py36hf8a1672_0
-  - patsy=0.5.0=py_1
-  - pcre=8.41=h470a237_2
+  - patsy=0.5.1=py_0
+  - pcre=8.41=hfc679d8_3
   - perl=5.22.0.1=0
   - pigz=2.3.4=0
-  - pip=18.0=py36_1
-  - psutil=5.4.7=py36_0
+  - pip=18.1=py36_1000
+  - psutil=5.4.8=py36h470a237_0
   - pthread-stubs=0.4=h470a237_1
-  - pycparser=2.18=py_1
-  - pyopenssl=18.0.0=py36_0
-  - pyparsing=2.2.0=py_1
-  - pyqt=5.6.0=py36h8210e8a_6
-  - pysocks=1.6.8=py36_1
-  - python=3.6.6=h5001a0f_0
-  - python-dateutil=2.7.3=py_0
-  - pytz=2018.5=py_0
-  - pyyaml=3.12=py36_1
+  - pycparser=2.19=py_0
+  - pyopenssl=18.0.0=py36_1000
+  - pyparsing=2.3.0=py_0
+  - pyqt=5.6.0=py36h8210e8a_7
+  - pyrsistent=0.14.7=py36h470a237_0
+  - pysocks=1.6.8=py36_1002
+  - python=3.6.7=h5001a0f_1
+  - python-dateutil=2.7.5=py_0
+  - pytz=2018.7=py_0
+  - pyyaml=3.13=py36h470a237_1
   - qt=5.6.2=hf70d934_9
-  - ratelimiter=1.2.0=py36_0
+  - ratelimiter=1.2.0=py36_1000
   - readline=7.0=haf1bffa_1
-  - requests=2.19.1=py36_1
-  - ruamel.yaml=0.15.52=py36_0
+  - requests=2.20.1=py36_1000
+  - ruamel.yaml=0.15.80=py36h470a237_0
+  - scipy=1.1.0=py36_blas_openblashb06ca3d_202
   - seaborn=0.9.0=py_0
-  - setuptools=40.0.0=py36_1
-  - sip=4.18=py36_1
-  - six=1.11.0=py36_1
-  - sqlite=3.24.0=h2f33b56_0
-  - statsmodels=0.9.0=py36_0
-  - tk=8.6.8=0
-  - tornado=5.1=py36h470a237_1
-  - urllib3=1.23=py36_1
-  - wheel=0.31.1=py36_1
-  - wrapt=1.10.11=py36_0
+  - setuptools=40.6.2=py36_0
+  - sip=4.18.1=py36hfc679d8_0
+  - six=1.11.0=py36_1001
+  - smmap2=2.0.5=py_0
+  - sqlite=3.25.3=hb1c47c0_0
+  - statsmodels=0.9.0=py36h7eb728f_0
+  - tk=8.6.9=ha92aebf_0
+  - tornado=5.1.1=py36h470a237_0
+  - urllib3=1.23=py36_1001
+  - wheel=0.32.3=py36_0
+  - wrapt=1.10.11=py36h470a237_1
   - xorg-libxau=1.0.8=h470a237_6
   - xorg-libxdmcp=1.1.2=h470a237_7
   - xz=5.2.4=h470a237_1
   - yaml=0.1.7=h470a237_1
   - zlib=1.2.11=h470a237_3
-  - blas=1.0=openblas
-  - bz2file=0.98=py36_1
-  - datrie=0.7.1=py36_0
-  - libopenblas=0.2.20=h9ac9557_7
+  - datrie=0.7.1=py36h7b6447c_1
+  - libgcc-ng=8.2.0=hdf63c60_1
   - nomkl=3.0=0
-  - numpy=1.14.2=py36_nomklh2b20989_1
-  - scipy=1.1.0=py36_nomklh9c1e066_0
   - pip:
-    - snakemake==5.2.2
+    - snakemake==5.3.0


### PR DESCRIPTION
Also, update require software versions (excluding IgBLAST).

We don’t use VSEARCH in the current version of the pipeline.