### PR TITLE
Try to make the cache work on macOS

### DIFF
--- a/src/igdiscover/cli/igblastwrap.py
+++ b/src/igdiscover/cli/igblastwrap.py
@@ -74,10 +74,10 @@ def main(args):
     if args.cache is not None:
         use_cache = args.cache
     if use_cache:
-        from .. import igblast as igblast_module
-
-        igblast_module._igblastcache = IgBlastCache()  # FIXME
-        logger.info("IgBLAST cache enabled")
+        cache = IgBlastCache()
+        logger.info("IgBLAST cache enabled (directory: '%s')", cache.cachedir)
+    else:
+        cache = None
     if args.threads == 0:
         args.threads = available_cpu_count()
     logger.info("Running IgBLAST on input reads")
@@ -95,7 +95,7 @@ def main(args):
             species=args.species,
             threads=args.threads,
             penalty=args.penalty,
-            use_cache=use_cache,
+            cache=cache,
         ):
             lines = record.splitlines()
             try:


### PR DESCRIPTION
possibly because macOS uses a different mechanism for spawning processes, the `_igblast_cache` global variable is not available from subprocesses, so if the cache is enabled, there is a crash. With this change, we pass the IgBlastCache to each worker, but we apparently also need to get rid of the `multiprocessing.Lock()` or get strange errors otherwise.