### PR TITLE
clonotypes: Implement --clustered option and allow multiple input tables

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,16 @@
 Changes
 =======
 
+development version
+-------------------
+
+* The ``clonotypes`` command has gained option ``--clustered``. It outputs the same information as
+  what the ``--members`` table contains, but in a more easily usable format. It is also faster than
+  using ``--members``.
+* The ``clonotypes`` command was sped up a little bit for the case when not using ``--clustered``.
+* The ``clonotypes`` gained the ability to accept multiple input tables. They are merged and then
+  the clustering is done on all sequences.
+
 v0.15 (2022-04-07)
 ------------------
 

--- a/src/igdiscover/cli/clonoquery.py
+++ b/src/igdiscover/cli/clonoquery.py
@@ -16,7 +16,6 @@ import logging
 from collections import defaultdict
 from contextlib import ExitStack
 
-import pandas as pd
 from xopen import xopen
 
 from ..table import read_table

--- a/src/igdiscover/cli/clonoquery.py
+++ b/src/igdiscover/cli/clonoquery.py
@@ -145,8 +145,9 @@ def read_and_preprocess_table(path, minimum_count=None, filter_empty=False):
     table = read_table(path, usecols=CLONOTYPE_COLUMNS)
     # Reorder columns
     table = table[CLONOTYPE_COLUMNS]
-    # Filter empty rows
+
     if filter_empty:
+        # Filter empty rows
         table = table[table.v_call != '']
     logger.info('Read table from %s with %s rows', path, len(table))
 

--- a/src/igdiscover/cli/clonoquery.py
+++ b/src/igdiscover/cli/clonoquery.py
@@ -103,10 +103,6 @@ def collect(querytable, reftable, mismatches, cdr3_core_slice, cdr3_column):
 
 def main(args):
     usecols = CLONOTYPE_COLUMNS
-    # TODO backwards compatibility
-    if ('FR1_aa_mut' not in pd.read_table(args.querytable, nrows=0).columns or
-            'FR1_aa_mut' not in pd.read_table(args.reftable, nrows=0).columns):
-        usecols = [col for col in usecols if not col.endswith('_aa_mut')]
     querytable = read_table(args.querytable, usecols=usecols)
     querytable = querytable[usecols]  # reorder columns
     # Filter empty rows (happens sometimes)

--- a/src/igdiscover/cli/clonoquery.py
+++ b/src/igdiscover/cli/clonoquery.py
@@ -19,31 +19,16 @@ from contextlib import ExitStack
 from xopen import xopen
 
 from ..table import read_table
-from ..utils import slice_arg
-from .clonotypes import is_similar_with_junction, CLONOTYPE_COLUMNS
+from .clonotypes import is_similar_with_junction, CLONOTYPE_COLUMNS, add_clonotyping_cdr3_arguments
 
 logger = logging.getLogger(__name__)
 
 
 def add_arguments(parser):
     arg = parser.add_argument
+    add_clonotyping_cdr3_arguments(arg)
     arg('--minimum-count', '-c', metavar='N', default=0, type=int,
         help='Discard all rows with count less than N. Default: %(default)s')
-    arg('--cdr3-core', default=None,
-        type=slice_arg, metavar='START:END',
-        help='START:END defines the non-junction region of CDR3 '
-            'sequences. Use negative numbers for END to count '
-            'from the end. Regions before and after are considered to '
-            'be junction sequence, and for two CDR3s to be considered '
-            'similar, at least one of the junctions must be identical. '
-            'Default: no junction region.')
-    arg('--mismatches', default=1, type=float,
-        help='No. of allowed mismatches between CDR3 sequences. '
-            'Can also be a fraction between 0 and 1 (such as 0.15), '
-            'interpreted relative to the length of the CDR3 (minus the front non-core). '
-            'Default: %(default)s')
-    arg('--aa', default=False, action='store_true',
-        help='Count CDR3 mismatches on amino-acid level. Default: Compare nucleotides.')
     arg('--summary', metavar='FILE',
         help='Write summary table to FILE')
     arg('reftable', help='Reference table with parsed and filtered '

--- a/src/igdiscover/cli/clonotypes.py
+++ b/src/igdiscover/cli/clonotypes.py
@@ -99,10 +99,6 @@ def run_clonotypes(
 ):
     logger.info('Reading input table ...')
     usecols = CLONOTYPE_COLUMNS
-    # TODO backwards compatibility
-    if 'FR1_aa_mut' not in pd.read_table(table, nrows=0).columns:
-        usecols = [col for col in usecols if not col.endswith('_aa_mut')]
-
     table = read_table(table, usecols=usecols)
     logger.info('Read table with %s rows', len(table))
     table.insert(5, 'CDR3_length', table['cdr3'].apply(len))

--- a/src/igdiscover/cli/clonotypes.py
+++ b/src/igdiscover/cli/clonotypes.py
@@ -141,7 +141,7 @@ def run_clonotypes(
                         f" {n} clonotypes and {k} sequences written"
                     )
                     progress_updated = elapsed
-    logger.info('%d clonotypes written', n)
+    logger.info('%d clonotypes and %d sequences written', n, k)
 
 
 def group_by_clonotype(table, mismatches, sort, cdr3_core, cdr3_column):

--- a/src/igdiscover/cli/clonotypes.py
+++ b/src/igdiscover/cli/clonotypes.py
@@ -123,7 +123,6 @@ def run_clonotypes(
     columns.remove('barcode')
     columns.remove('count')
     columns.insert(0, 'count')
-    columns.insert(columns.index('cdr3'), 'CDR3_length')
     print(*columns, sep='\t')
     members_header = True
     cdr3_column = 'cdr3_aa' if aa else 'cdr3'

--- a/src/igdiscover/cli/clonotypes.py
+++ b/src/igdiscover/cli/clonotypes.py
@@ -101,18 +101,7 @@ def run_clonotypes(
     cdr3_core=None,
     mindiffrate=True,
 ):
-    logger.info('Reading input tables ...')
-    tables = [read_table(path) for path in table_paths]
-
-    if len(table_paths) == 1:
-        table = tables[0]
-        has_file_id = False
-        logger.info('Read table with %s rows', len(table))
-    else:
-        table = pd.concat(tables, keys=range(len(table_paths)), names=["file_id"])
-        has_file_id = True
-        logger.info("Read %d tables with %s rows in total", len(tables), len(table))
-        del tables
+    table, has_file_id = read_tables(table_paths)
 
     table.insert(list(table.columns).index('cdr3'), 'CDR3_length', table['cdr3'].apply(len))
     table = table[table['CDR3_length'] > 0]
@@ -188,6 +177,22 @@ def run_clonotypes(
                     progress_updated = elapsed
 
     logger.info('%d clonotypes and %d sequences written', n, k)
+
+
+def read_tables(table_paths):
+    logger.info('Reading input tables ...')
+    tables = [read_table(path) for path in table_paths]
+    if len(table_paths) == 1:
+        table = tables[0]
+        has_file_id = False
+        logger.info('Read table with %s rows', len(table))
+    else:
+        table = pd.concat(tables, keys=range(len(table_paths)), names=["file_id"])
+        has_file_id = True
+        logger.info("Read %d tables with %s rows in total", len(tables), len(table))
+        del tables
+
+    return table, has_file_id
 
 
 def group_by_clonotype(table, mismatches, sort, cdr3_core, cdr3_column):

--- a/src/igdiscover/cli/clonotypes.py
+++ b/src/igdiscover/cli/clonotypes.py
@@ -50,6 +50,15 @@ def add_arguments(parser):
         help='Print out only the first N groups')
     arg('--v-shm-threshold', default=5, type=float,
         help='V SHM threshold for _mindiffrate computations')
+    add_clonotyping_cdr3_arguments(arg)
+    arg('--no-mindiffrate', dest='mindiffrate', action='store_false', default=True,
+        help='Do not add _mindiffrate columns')
+    arg('--members', metavar='FILE',
+        help='Write member table to FILE')
+    arg('table', help='Table with parsed and filtered IgBLAST results')
+
+
+def add_clonotyping_cdr3_arguments(arg):
     arg('--cdr3-core', default=None,
         type=slice_arg, metavar='START:END',
         help='START:END defines the non-junction region of CDR3 '
@@ -65,11 +74,6 @@ def add_arguments(parser):
             'Default: %(default)s')
     arg('--aa', default=False, action='store_true',
         help='Count CDR3 mismatches on amino-acid level. Default: Compare nucleotides.')
-    arg('--no-mindiffrate', dest='mindiffrate', action='store_false', default=True,
-        help='Do not add _mindiffrate columns')
-    arg('--members', metavar='FILE',
-        help='Write member table to FILE')
-    arg('table', help='Table with parsed and filtered IgBLAST results')
 
 
 def main(args):

--- a/src/igdiscover/cli/clonotypes.py
+++ b/src/igdiscover/cli/clonotypes.py
@@ -57,10 +57,10 @@ def add_arguments(parser):
     arg('--members', metavar='FILE',
         help='Write member table to FILE')
     arg('--clustered', metavar='FILE',
-        help='Fast mode: Only write a table with added clonotype ids to FILE, then exit. '
+        help='Write a table with added clonotype ids to FILE. '
              'This table contains the same information as the --members table, '
              'but is easier to parse (the clonotype_id column denotes the clonotype a '
-             'sequence belongs to). No members or clonotypes tables are created if you use this.')
+             'sequence belongs to).')
     arg(dest='table_paths', metavar='table', nargs='+',
         help='Table(s) with parsed and filtered IgBLAST results. If more than one table is '
              'provided, they are merged and treated as a single dataset for clonotype assignment, '
@@ -125,8 +125,7 @@ def run_clonotypes(
     columns.remove('count')
     columns.insert(0, 'count')
     columns.insert(columns.index('cdr3'), 'CDR3_length')
-    if not clustered:
-        print(*columns, sep='\t')
+    print(*columns, sep='\t')
     members_header = True
     cdr3_column = 'cdr3_aa' if aa else 'cdr3'
 
@@ -142,7 +141,6 @@ def run_clonotypes(
     if clustered:
         table.to_csv(clustered, sep="\t", index=False)
         logger.info('Found %d clonotypes', table["clonotype_id"].max() + 1)
-        return
 
     with ExitStack() as stack:
         if members:

--- a/src/igdiscover/cli/clonotypes.py
+++ b/src/igdiscover/cli/clonotypes.py
@@ -179,7 +179,7 @@ def group_by_cdr3(table, mismatches, cdr3_core, cdr3_column):
     to .groupby().
     """
     # Cluster all unique CDR3s by Hamming distance
-    sequences = list(set(table[cdr3_column]))
+    sequences = sorted(set(table[cdr3_column]))
 
     def linked(s, t):
         return is_similar_with_junction(s, t, mismatches, cdr3_core)

--- a/src/igdiscover/cli/clonotypes.py
+++ b/src/igdiscover/cli/clonotypes.py
@@ -214,7 +214,7 @@ def add_clonotype_id(table: pd.DataFrame, mismatches: int, cdr3_column: str, cdr
     """
     table["vjlen_id"] = table.groupby(["v_call", "j_call", "CDR3_length"], sort=False).ngroup()
     table["cdr3_cluster_id"] = 0
-    table = table.groupby("vjlen_id", group_keys=True, sort=False).apply(
+    table = table.groupby("vjlen_id", group_keys=False, sort=False).apply(
         assign_cdr3_cluster_id,
         mismatches=mismatches,
         cdr3_core=cdr3_core,

--- a/src/igdiscover/cli/clonotypes.py
+++ b/src/igdiscover/cli/clonotypes.py
@@ -165,6 +165,7 @@ def group_by_clonotype(table, mismatches, sort, cdr3_core, cdr3_column):
     table.insert(
         0, "vjlen_id", table.groupby(["v_call", "j_call", "CDR3_length"]).ngroup()
     )
+    table.insert(1, "cdr3_cluster_id", 0)
     table = table.groupby("vjlen_id", group_keys=True).apply(
         assign_cdr3_cluster_id,
         mismatches=mismatches,
@@ -182,12 +183,11 @@ def group_by_clonotype(table, mismatches, sort, cdr3_core, cdr3_column):
         if prev_v != v_gene:
             logger.info('Processing %s', v_gene)
         prev_v = v_gene
-        g = group.drop("clonotype_id", axis=1)
         if sort:
             # When sorting by group size is requested, we need to buffer results
-            groups.append(g)
+            groups.append(group)
         else:
-            yield g
+            yield group
     if sort:
         logger.info("Sorting by size ...")
         yield from sorted(groups, key=len, reverse=True)
@@ -201,7 +201,6 @@ def assign_cdr3_cluster_id(table, mismatches, cdr3_core, cdr3_column):
     # Cluster all unique CDR3s by Hamming distance
     sequences = sorted(set(table[cdr3_column]))
     if len(sequences) == 1:
-        table.insert(1, "cdr3_cluster_id", 0)  # TODO remove?
         return table
 
     def linked(s, t):

--- a/src/igdiscover/cli/clonotypes.py
+++ b/src/igdiscover/cli/clonotypes.py
@@ -103,7 +103,7 @@ def run_clonotypes(
 ):
     logger.info('Reading input tables ...')
     usecols = CLONOTYPE_COLUMNS
-    tables = [read_table(path, usecols=usecols) for path in table_paths]
+    tables = [read_table(path) for path in table_paths]
 
     if len(table_paths) == 1:
         table = tables[0]
@@ -219,7 +219,7 @@ def add_clonotype_id(table: pd.DataFrame, mismatches: int, cdr3_column: str, cdr
         cdr3_column=cdr3_column,
     )
     table.insert(
-        list(table.columns).index("sequence_id") + 1,
+        0,
         "clonotype_id",
         table.groupby(["vjlen_id", "cdr3_cluster_id"], sort=False).ngroup()
     )

--- a/src/igdiscover/cli/clonotypes.py
+++ b/src/igdiscover/cli/clonotypes.py
@@ -171,13 +171,18 @@ def group_by_clonotype(table, mismatches, sort, cdr3_core, cdr3_column):
         cdr3_core=cdr3_core,
         cdr3_column=cdr3_column,
     )
+    table.insert(
+        0, "clonotype_id", table.groupby(["vjlen_id", "cdr3_cluster_id"]).ngroup()
+    )
+    del table["vjlen_id"]
+    del table["cdr3_cluster_id"]
     groups = []
-    for _, group in table.groupby(["vjlen_id", "cdr3_cluster_id"]):
+    for _, group in table.groupby("clonotype_id"):
         v_gene = group["v_call"].iloc[0]
         if prev_v != v_gene:
             logger.info('Processing %s', v_gene)
         prev_v = v_gene
-        g = group.drop(["vjlen_id", "cdr3_cluster_id"], axis=1)
+        g = group.drop("clonotype_id", axis=1)
         if sort:
             # When sorting by group size is requested, we need to buffer results
             groups.append(g)
@@ -211,7 +216,6 @@ def assign_cdr3_cluster_id(table, mismatches, cdr3_core, cdr3_column):
             cluster_ids[cdr3] = cluster_id
 
     # Assign cluster id to each row
-    # table.insert(1, "cdr3_cluster_id", 0)
     table["cdr3_cluster_id"] = table[cdr3_column].apply(lambda cdr3: cluster_ids[cdr3])
     return table
 

--- a/src/igdiscover/cli/clonotypes.py
+++ b/src/igdiscover/cli/clonotypes.py
@@ -181,11 +181,13 @@ def group_by_clonotype(table, mismatches, sort, cdr3_core, cdr3_column):
 def group_by_cdr3(table, mismatches, cdr3_core, cdr3_column):
     """
     Cluster the rows of the table by Hamming distance between
-    their CDR3 sequences. Yield (index, group) tuples similar 
-    to .groupby().
+    their CDR3 sequences.
     """
     # Cluster all unique CDR3s by Hamming distance
     sequences = sorted(set(table[cdr3_column]))
+    if len(sequences) == 1:
+        yield table
+        return
 
     def linked(s, t):
         return is_similar_with_junction(s, t, mismatches, cdr3_core)

--- a/src/igdiscover/cli/clonotypes.py
+++ b/src/igdiscover/cli/clonotypes.py
@@ -189,13 +189,8 @@ def group_by_clonotype(table, mismatches, sort, cdr3_core, cdr3_column):
     Yield clonotype groups. Each item is a DataFrame with all the members of the
     clonotype. The input table must have "clonotype_id" column.
     """
-    prev_v = None
     groups = []
     for _, group in table.groupby("clonotype_id"):
-        v_gene = group["v_call"].iloc[0]
-        if prev_v != v_gene:
-            logger.info('Processing %s', v_gene)
-        prev_v = v_gene
         if sort:
             # When sorting by group size is requested, we need to buffer results
             groups.append(group)

--- a/src/igdiscover/cli/clonotypes.py
+++ b/src/igdiscover/cli/clonotypes.py
@@ -181,7 +181,16 @@ def run_clonotypes(
 
 def read_tables(table_paths):
     logger.info('Reading input tables ...')
-    tables = [read_table(path) for path in table_paths]
+    required_alignment_columns = [
+        "sequence_alignment",  # as per AIRR standard
+        "sequence_alignment_aa",  # because it is used by us
+        "germline_alignment",  # as per AIRR standard
+    ]
+    skipcols = [
+        name for name in pd.read_table(table_paths[0], nrows=0).columns
+        if "_alignment" in name and name not in required_alignment_columns
+    ]
+    tables = [read_table(path, skipcols=skipcols) for path in table_paths]
     if len(table_paths) == 1:
         table = tables[0]
         has_file_id = False

--- a/src/igdiscover/table.py
+++ b/src/igdiscover/table.py
@@ -208,7 +208,7 @@ def transform_usecols(usecols, available_columns):
     for col in usecols:
         if col not in available_columns and col in new_to_old:
             logger.info(
-                "Requested column %s not found, assuming old file format and using %s instead",
+                "Requested column '%s' not found, assuming old file format and using '%s' instead",
                 col, new_to_old[col]
             )
             new_usecols.add(new_to_old[col])

--- a/src/igdiscover/table.py
+++ b/src/igdiscover/table.py
@@ -169,14 +169,20 @@ def fix_columns(d, usecols, recompute_cols):
     return d
 
 
-def read_table(path, usecols=None, log=False, nrows=None, chunksize=None):
+def read_table(path, usecols=None, log=False, nrows=None, chunksize=None, skipcols=None):
     """
     Read in the table created by the parse subcommand (typically named *.tab)
     """
+    assert not (usecols and skipcols)
     if usecols:
         # Adjust requested column names in case the input uses old column names
         available_columns = set(pd.read_table(path, nrows=0).columns)
         new_usecols, recompute_cols = transform_usecols(usecols, available_columns)
+    elif skipcols:
+        available_columns = set(pd.read_table(path, nrows=0).columns)
+        skipcols = set(skipcols)
+        new_usecols = [colname for colname in available_columns if colname not in skipcols]
+        recompute_cols = []
     else:
         new_usecols = usecols
         recompute_cols = []

--- a/src/igdiscover/table.py
+++ b/src/igdiscover/table.py
@@ -59,6 +59,7 @@ _STRING_COLUMNS = [
     'locus',  # categorical
     'stop',  # bool
     'productive',  # bool
+    'vj_in_frame',  # bool
     'UTR',
     'leader',
     'CDR1_nt',

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -216,7 +216,7 @@ def test_snakemake_final(has_filtered_tsv):
 
 
 def test_clonotypes(has_filtered_tsv):
-    run_clonotypes(has_filtered_tsv / "iteration-01/assigned.tsv.gz", limit=5)
+    run_clonotypes([has_filtered_tsv / "iteration-01/assigned.tsv.gz"], limit=5)
 
 
 def test_fastq_input(has_filtered_tsv, tmp_path):


### PR DESCRIPTION
This works quite similar to the clonoquery subcommand, but it allows querying multiple reference tables, which are simply merged into one table before querying. For now, this is a separate subcommand because the order of arguments needed to change: `clonoquery` expects reference, then query, but since `clonoquery2`accepts multiple references, the order for that command is query, then reference (plus more references).

## To Do

- [x] Output a "members" table even if `--clustered` is provided
- [x] Make `--clustered` output contain all the AIRR columns
